### PR TITLE
Increase max logs in file

### DIFF
--- a/src/parser.h
+++ b/src/parser.h
@@ -9,7 +9,7 @@
 
 #include "blackbox_fielddefs.h"
 
-#define FLIGHT_LOG_MAX_LOGS_IN_FILE 31
+#define FLIGHT_LOG_MAX_LOGS_IN_FILE 1000
 #define FLIGHT_LOG_MAX_FIELDS 128
 
 #define FLIGHT_LOG_FIELD_INDEX_ITERATION 0


### PR DESCRIPTION
In parser.h, FLIGHT_LOG_MAX_LOGS_IN_FILE is set to 31,
and I have seen log files with 97 logs. For example when using Betaflight F4 with Betaflight 3.5.5.
Tested to increase to 1000 and it worked.