### PR TITLE
Gpx file altitude in meter

### DIFF
--- a/src/gpxwriter.h
+++ b/src/gpxwriter.h
@@ -16,7 +16,7 @@ typedef struct gpxWriter_t {
     char *filename;
 } gpxWriter_t;
 
-void gpxWriterAddPoint(gpxWriter_t *gpx, int64_t time, int32_t lat, int32_t lon, int16_t altitude);
+void gpxWriterAddPoint(gpxWriter_t *gpx, time_t dateTime, int64_t time, int32_t lat, int32_t lon, float altitude);
 gpxWriter_t* gpxWriterCreate(const char *filename);
 void gpxWriterDestroy(gpxWriter_t* gpx);
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -144,6 +144,7 @@ typedef struct flightLogFrameDef_t {
 struct flightLogPrivate_t;
 
 typedef struct flightLog_t {
+	time_t dateTime; //GPS start date and time
     flightLogStatistics_t stats;
 
     //Information about fields which we need to decode them properly


### PR DESCRIPTION
Betaflight blackbox logs altitude in centimiter that was earlier logged as integer in gpx file, while gpx file altitude standard unit is meter. This is now changed to log as float meter in gpx file, and with optional user altitude offset.