### PR TITLE
GPX out read logged alt in dm for Betaflight 4

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -392,6 +392,16 @@ static size_t parseHeaderLine(flightLog_t *log, mmapStream_t *stream, ParserStat
             log->sysConfig.firmwareType = FIRMWARE_TYPE_CLEANFLIGHT;
         else
             log->sysConfig.firmwareType = FIRMWARE_TYPE_BASEFLIGHT;
+    } else if (strcmp(fieldName, "Firmware revision") == 0) {
+        char fieldCopy[200];
+        strcpy(fieldCopy, fieldValue);
+        char* fcName = strtok(fieldCopy, " "); //Read firmware name
+        if (!strcmp(fcName, "Betaflight")) { //Version text location known for Betaflight firmware
+            char* fcVersion = strtok(NULL, " "); //Firmware version text
+            strcpy(log->private->fcVersion, fcVersion);
+        } else {
+            log->private->fcVersion[0] = 0; //Indicate that firmware version unknown
+        }
     } else if (strcmp(fieldName, "minthrottle") == 0) {
         log->sysConfig.minthrottle = atoi(fieldValue);
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -177,6 +177,8 @@ typedef struct flightLogPrivate_t
 {
     int dataVersion;
 
+    char fcVersion[30];
+
     // Blackbox state:
     int64_t blackboxHistoryRing[3][FLIGHT_LOG_MAX_FIELDS];
 


### PR DESCRIPTION
Betaflight 4 log altitude in unit dm instead of cm as in earlier versions. Exporting to GPX file now check firmware version and read as dm unit if log file from Betaflight 4 or later.