### PR TITLE
Allow building 'blackbox_decode' on msys2.

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -18,6 +18,9 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <assert.h>
+#if defined(__MINGW64__) || defined(__MINGW32__)
+    #include <time.h>
+#endif
 
 #include "parser.h"
 #include "tools.h"

--- a/src/platform.h
+++ b/src/platform.h
@@ -41,6 +41,10 @@
     #include <sys/stat.h>
 #endif
 
+#if defined(__MINGW64__) || defined(__MINGW32__)
+    #include <sys/stat.h>
+#endif
+
 #ifdef WIN32
     #define snprintf _snprintf
 #endif


### PR DESCRIPTION
Tested under msys2 ucrt64.

Without this various compilation errors occur.

binary: [blackbox_decode.zip](https://github.com/betaflight/blackbox-tools/files/11680424/blackbox_decode.zip)
example output:
```
$ ./obj/blackbox_decode.exe --debug obj/3INCH_D_08_MM_1.4_DW_0.6.bbl
Decoding log 'obj/3INCH_D_08_MM_1.4_DW_0.6.bbl' to 'obj/3INCH_D_08_MM_1.4_DW_0.6.01.csv'...
Data file contained no events

Log 1 of 1, start 00:05.636, end 00:42.493, duration 00:36.857

Statistics
Looptime            958 avg          171.5 std dev (17.9%)
I frames    1165   59.7 bytes avg    69545 bytes total
P frames   36086   32.1 bytes avg  1157044 bytes total
H frames      63    0.0 bytes avg        0 bytes total
E frames       2    8.5 bytes avg       17 bytes total
S frames       6    3.0 bytes avg       18 bytes total
Frames     37251   32.9 bytes avg  1226589 bytes total
Data rate 1010Hz  34460 bytes/s     344700 baud

0 frames failed to decode, rendering 27 loop iterations unreadable. 260736 iterations are missing in total (32249ms, 87.50%)
```
