### PR TITLE
encoder_testbed usage/help

### DIFF
--- a/src/encoder_testbed.c
+++ b/src/encoder_testbed.c
@@ -757,11 +757,6 @@ void parseCommandlineOptions(int argc, char **argv)
             break;
 
         switch (c) {
-            case 0:
-                /* If this option set a flag, do nothing else now. */
-                if (long_options[option_index].flag != 0)
-                    break;
-                break;
             case 'h':
                 printUsage(argv[0]);
                 exit(0);

--- a/src/encoder_testbed.c
+++ b/src/encoder_testbed.c
@@ -733,7 +733,6 @@ static void printUsage(const char *argv0)
     fprintf(stdout, "Example:\n");
     fprintf(stdout, "  %s INPUT.bbl > OUTPUT.bbl\n", argv0);
     fprintf(stdout, "\n");
-
 }
 
 void parseCommandlineOptions(int argc, char **argv)

--- a/src/encoder_testbed.c
+++ b/src/encoder_testbed.c
@@ -716,23 +716,23 @@ void onFrameReady(flightLog_t *fl, bool frameValid, int64_t *frame, uint8_t fram
 
 static void printUsage(const char *argv0)
 {
-    fprintf(stderr, "Usage: %s [options] <logfile>\n", argv0);
-    fprintf(stderr, "\n");
-    fprintf(stderr, "This tool reads in a flight log and re-encodes it using a private copy of the encoder.\n");
-    fprintf(stderr, "This allows experiments to be run on improving the encoder's efficiency, and allows\n");
-    fprintf(stderr, "any changes to the encoder to be verified (by comparing decoded logs against the\n");
-    fprintf(stderr, "ones produced by the original encoder).\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "The <logfile> should be a binary flight data log, typically with a .bbl or .bfl extension.\n");
-    fprintf(stderr, "The file extension is not strictly checked and is case-insensitive.\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "Options:\n");
-    fprintf(stderr, "  --debug    Enable debug output.\n");
-    fprintf(stderr, "  --help     Display this help message and exit.\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "Example:\n");
-    fprintf(stderr, "  %s INPUT.bbl > OUTPUT.bbl\n", argv0);
-    fprintf(stderr, "\n");
+    fprintf(stdout, "Usage: %s [options] <logfile>\n", argv0);
+    fprintf(stdout, "\n");
+    fprintf(stdout, "This tool reads in a flight log and re-encodes it using a private copy of the encoder.\n");
+    fprintf(stdout, "This allows experiments to be run on improving the encoder's efficiency, and allows\n");
+    fprintf(stdout, "any changes to the encoder to be verified (by comparing decoded logs against the\n");
+    fprintf(stdout, "ones produced by the original encoder).\n");
+    fprintf(stdout, "\n");
+    fprintf(stdout, "The <logfile> should be a binary flight data log, typically with a .bbl or .bfl extension.\n");
+    fprintf(stdout, "The file extension is not strictly checked and is case-insensitive.\n");
+    fprintf(stdout, "\n");
+    fprintf(stdout, "Options:\n");
+    fprintf(stdout, "  --debug    Enable debug output.\n");
+    fprintf(stdout, "  --help     Display this help message and exit.\n");
+    fprintf(stdout, "\n");
+    fprintf(stdout, "Example:\n");
+    fprintf(stdout, "  %s INPUT.bbl > OUTPUT.bbl\n", argv0);
+    fprintf(stdout, "\n");
 
 }
 

--- a/src/encoder_testbed.c
+++ b/src/encoder_testbed.c
@@ -714,6 +714,28 @@ void onFrameReady(flightLog_t *fl, bool frameValid, int64_t *frame, uint8_t fram
     }
 }
 
+static void printUsage(const char *argv0)
+{
+    fprintf(stderr, "Usage: %s [options] <logfile>\n", argv0);
+    fprintf(stderr, "\n");
+    fprintf(stderr, "This tool reads in a flight log and re-encodes it using a private copy of the encoder.\n");
+    fprintf(stderr, "This allows experiments to be run on improving the encoder's efficiency, and allows\n");
+    fprintf(stderr, "any changes to the encoder to be verified (by comparing decoded logs against the\n");
+    fprintf(stderr, "ones produced by the original encoder).\n");
+    fprintf(stderr, "\n");
+    fprintf(stderr, "The <logfile> should be a binary flight data log, typically with a .bbl or .bfl extension.\n");
+    fprintf(stderr, "The file extension is not strictly checked and is case-insensitive.\n");
+    fprintf(stderr, "\n");
+    fprintf(stderr, "Options:\n");
+    fprintf(stderr, "  --debug    Enable debug output.\n");
+    fprintf(stderr, "  --help     Display this help message and exit.\n");
+    fprintf(stderr, "\n");
+    fprintf(stderr, "Example:\n");
+    fprintf(stderr, "  %s INPUT.bbl > OUTPUT.bbl\n", argv0);
+    fprintf(stderr, "\n");
+
+}
+
 void parseCommandlineOptions(int argc, char **argv)
 {
     int c;
@@ -722,16 +744,33 @@ void parseCommandlineOptions(int argc, char **argv)
     {
         static struct option long_options[] = {
             {"debug", no_argument, &optionDebug, 1},
+            {"help",  no_argument, 0, 'h'},
             {0, 0, 0, 0}
         };
 
         int option_index = 0;
 
-        c = getopt_long (argc, argv, "", long_options, &option_index);
+        c = getopt_long(argc, argv, "h", long_options, &option_index);
 
         /* Detect the end of the options. */
         if (c == -1)
             break;
+
+        switch (c) {
+            case 0:
+                /* If this option set a flag, do nothing else now. */
+                if (long_options[option_index].flag != 0)
+                    break;
+                break;
+            case 'h':
+                printUsage(argv[0]);
+                exit(0);
+            case '?':
+                /* getopt_long already printed an error message. */
+                exit(1);
+            default:
+                break;
+        }
     }
 
     if (optind < argc)
@@ -1049,7 +1088,7 @@ int main(int argc, char **argv)
     parseCommandlineOptions(argc, argv);
 
     if (!optionFilename) {
-        fprintf(stderr, "Missing log filename argument\n");
+        printUsage(argv[0]);
         return -1;
     }
 


### PR DESCRIPTION
- adds usage output when no parameter specified
- adds `--help` parameter for the same information.

```
$ ./obj/encoder_testbed --help
Usage: ./obj/encoder_testbed [options] <logfile>

This tool reads in a flight log and re-encodes it using a private copy of the encoder.
This allows experiments to be run on improving the encoder's efficiency, and allows
any changes to the encoder to be verified (by comparing decoded logs against the
ones produced by the original encoder).

The <logfile> should be a binary flight data log, typically with a .bbl or .bfl extension.
The file extension is not strictly checked and is case-insensitive.

Options:
  --debug    Enable debug output.
  --help     Display this help message and exit.

Example:
  ./obj/encoder_testbed INPUT.bbl > OUTPUT.bbl

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a `--help` (`-h`) command-line option to display detailed usage instructions, including input format, available options, and example usage.

* **Bug Fixes**
  * Improved error handling and user guidance when required arguments are missing or unknown options are provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->