### PR TITLE
Refactor: Centralize base name prefix extraction logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ OBJECT_DIR	 = $(ROOT)/obj
 BIN_DIR		 = $(ROOT)/obj
 
 # Source files common to all targets
-COMMON_SRC	 = parser.c tools.c platform.c stream.c decoders.c units.c blackbox_fielddefs.c semver.c
+COMMON_SRC	 = parser.c tools.c platform.c stream.c decoders.c units.c blackbox_fielddefs.c semver.c utils.c
 DECODER_SRC	 = $(COMMON_SRC) blackbox_decode.c gpxwriter.c imu.c battery.c stats.c
 RENDERER_SRC = $(COMMON_SRC) blackbox_render.c datapoints.c embeddedfont.c expo.c imu.c
 ENCODER_TESTBED_SRC = $(COMMON_SRC) encoder_testbed.c encoder_testbed_io.c

--- a/src/utils.c
+++ b/src/utils.c
@@ -30,6 +30,16 @@ const char *findLastPathSeparator(const char *path)
 void extractBaseNamePrefix(const char *filename, const char *logNameEnd, bool hasOutputDir,
                           const char **outBaseNamePrefix, int *outBaseNamePrefixLen,
                           const char **outOutputPrefix, int *outOutputPrefixLen) {
+    // Input validation: ensure pointers are valid and logNameEnd >= filename
+    if (!filename || !logNameEnd || logNameEnd < filename) {
+        // Set all outputs to safe defaults
+        if (outBaseNamePrefix) *outBaseNamePrefix = NULL;
+        if (outBaseNamePrefixLen) *outBaseNamePrefixLen = 0;
+        if (outOutputPrefix) *outOutputPrefix = NULL;
+        if (outOutputPrefixLen) *outOutputPrefixLen = 0;
+        return;
+    }
+    
     const char *lastSlash;
     if (hasOutputDir) {
         lastSlash = findLastPathSeparator(filename);

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,0 +1,51 @@
+#include "utils.h"
+#include <string.h>
+
+/**
+ * Find the last path separator in a string (either '/' or '\' on Windows).
+ * Returns a pointer to the last path separator, or NULL if none found.
+ */
+const char *findLastPathSeparator(const char *path)
+{
+    const char *lastSlash = strrchr(path, '/');
+#ifdef WIN32
+    const char *lastBackslash = strrchr(path, '\\');
+    if (lastBackslash && (!lastSlash || lastBackslash > lastSlash)) {
+        lastSlash = lastBackslash;
+    }
+#endif
+    return lastSlash;
+}
+
+/**
+ * Extract base name prefix from a filename based on output directory settings
+ * @param filename The input filename to process
+ * @param logNameEnd Pointer to the end of the log name (before extension)
+ * @param hasOutputDir Whether an output directory is specified
+ * @param outBaseNamePrefix Pointer to store the base name prefix
+ * @param outBaseNamePrefixLen Pointer to store the base name prefix length
+ * @param outOutputPrefix Pointer to store the output prefix
+ * @param outOutputPrefixLen Pointer to store the output prefix length
+ */
+void extractBaseNamePrefix(const char *filename, const char *logNameEnd, bool hasOutputDir,
+                          const char **outBaseNamePrefix, int *outBaseNamePrefixLen,
+                          const char **outOutputPrefix, int *outOutputPrefixLen) {
+    const char *lastSlash;
+    if (hasOutputDir) {
+        lastSlash = findLastPathSeparator(filename);
+        if (lastSlash) {
+            if (outBaseNamePrefix) *outBaseNamePrefix = lastSlash + 1;
+            if (outBaseNamePrefixLen) *outBaseNamePrefixLen = logNameEnd - (lastSlash + 1);
+        } else {
+            if (outBaseNamePrefix) *outBaseNamePrefix = filename;
+            if (outBaseNamePrefixLen) *outBaseNamePrefixLen = logNameEnd - filename;
+        }
+        if (outOutputPrefix) *outOutputPrefix = NULL;
+        if (outOutputPrefixLen) *outOutputPrefixLen = 0;
+    } else {
+        if (outOutputPrefix) *outOutputPrefix = filename;
+        if (outOutputPrefixLen) *outOutputPrefixLen = logNameEnd - filename;
+        if (outBaseNamePrefix) *outBaseNamePrefix = filename;
+        if (outBaseNamePrefixLen) *outBaseNamePrefixLen = logNameEnd - filename;
+    }
+}

--- a/src/utils.c
+++ b/src/utils.c
@@ -7,6 +7,11 @@
  */
 const char *findLastPathSeparator(const char *path)
 {
+    // Input validation: return NULL if path is NULL
+    if (!path) {
+        return NULL;
+    }
+    
     const char *lastSlash = strrchr(path, '/');
 #ifdef WIN32
     const char *lastBackslash = strrchr(path, '\\');

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,0 +1,27 @@
+#ifndef UTILS_H_
+#define UTILS_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/**
+ * Find the last path separator in a string (either '/' or '\' on Windows).
+ * Returns a pointer to the last path separator, or NULL if none found.
+ */
+const char *findLastPathSeparator(const char *path);
+
+/**
+ * Extract base name prefix from a filename based on output directory settings
+ * @param filename The input filename to process
+ * @param logNameEnd Pointer to the end of the log name (before extension)
+ * @param hasOutputDir Whether an output directory is specified
+ * @param outBaseNamePrefix Pointer to store the base name prefix
+ * @param outBaseNamePrefixLen Pointer to store the base name prefix length
+ * @param outOutputPrefix Pointer to store the output prefix
+ * @param outOutputPrefixLen Pointer to store the output prefix length
+ */
+void extractBaseNamePrefix(const char *filename, const char *logNameEnd, bool hasOutputDir,
+                          const char **outBaseNamePrefix, int *outBaseNamePrefixLen,
+                          const char **outOutputPrefix, int *outOutputPrefixLen);
+
+#endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -6,7 +6,8 @@
 
 /**
  * Find the last path separator in a string (either '/' or '\' on Windows).
- * Returns a pointer to the last path separator, or NULL if none found.
+ * @param path The input path string to search (can be NULL)
+ * @return Pointer to the last path separator, or NULL if none found or path is NULL
  */
 const char *findLastPathSeparator(const char *path);
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -12,13 +12,14 @@ const char *findLastPathSeparator(const char *path);
 
 /**
  * Extract base name prefix from a filename based on output directory settings
- * @param filename The input filename to process
- * @param logNameEnd Pointer to the end of the log name (before extension)
+ * @param filename The input filename to process (must not be NULL)
+ * @param logNameEnd Pointer to the end of the log name (must not be NULL and >= filename)
  * @param hasOutputDir Whether an output directory is specified
- * @param outBaseNamePrefix Pointer to store the base name prefix
- * @param outBaseNamePrefixLen Pointer to store the base name prefix length
- * @param outOutputPrefix Pointer to store the output prefix
- * @param outOutputPrefixLen Pointer to store the output prefix length
+ * @param outBaseNamePrefix Pointer to store the base name prefix (can be NULL)
+ * @param outBaseNamePrefixLen Pointer to store the base name prefix length (can be NULL)
+ * @param outOutputPrefix Pointer to store the output prefix (can be NULL)
+ * @param outOutputPrefixLen Pointer to store the output prefix length (can be NULL)
+ * @note If invalid input is provided, all output parameters are set to NULL/0 and function returns early
  */
 void extractBaseNamePrefix(const char *filename, const char *logNameEnd, bool hasOutputDir,
                           const char **outBaseNamePrefix, int *outBaseNamePrefixLen,


### PR DESCRIPTION
- AI Generated code.
- Replaced duplicated logic for extracting the base name prefix and output prefix in `decodeFlightLog` with a new static helper function, `extractBaseNamePrefix`. Added its prototype near the top of the file and moved the implementation to the end. This improves maintainability and reduces code duplication. No changes to program logic.
- revolves comments in https://github.com/betaflight/blackbox-tools/pull/58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Refactor**
  * Improved internal logic for determining file naming prefixes, resulting in clearer and more maintainable code. No changes to user-facing features or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->