### PR TITLE
fix: vbatLatest Scale

### DIFF
--- a/src/blackbox_decode.c
+++ b/src/blackbox_decode.c
@@ -213,7 +213,12 @@ static bool fprintfMainFieldInUnit(flightLog_t *log, FILE *file, int fieldIndex,
             return true;
         case UNIT_VOLTS:
             // Betaflight already does the ADC conversion
-            fprintf(file, "%.1f", (double) fieldValue / 10);
+            // vbat scaling changed in firmware 4.3.0 - use different scaling for older versions
+            if (semver_gte_string(log->private->fcVersion, "4.3.0")) {
+                fprintf(file, "%.2f", (double) fieldValue / 100);
+            } else {
+                fprintf(file, "%.1f", (double) fieldValue / 10);
+            }
             return true;
         case UNIT_MILLIAMPS:
             // Betaflight already does the ADC conversion


### PR DESCRIPTION
## Use semver to scale vbatLatest
- 4.3.0 and later is scaled to hundredths
- earlier is scaled to tenths

6S before:
![image](https://github.com/user-attachments/assets/81277e1e-4aaf-4a79-a389-84facdbb31af)

after:
![image](https://github.com/user-attachments/assets/c9b4ae74-9b6c-49c8-beff-2180319773b5)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved voltage value display to ensure correct formatting based on firmware version, providing more accurate readings for newer firmware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->