### PR TITLE
ci: add arm64 targets, fix deprecated runners, fix cairo/freetype linkage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
           - name: Linux
             os: ubuntu-latest
 
-          - name: macOS
-            os: macos-13
+          - name: macOS (x86_64)
+            os: macos-15-intel
 
           - name: macOS (arm64)
             os: macos-15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: 
+on:
   workflow_call:
 
 jobs:
@@ -16,22 +16,30 @@ jobs:
           - name: macOS
             os: macos-13
 
+          - name: macOS (arm64)
+            os: macos-15
+            extra_make_args: DEBUG=RELEASE DEBUG_FLAGS="" ARCH_FLAGS="-mcpu=apple-m1"
+
+          - name: Linux (arm64)
+            os: ubuntu-24.04-arm
+            extra_make_args: DEBUG=RELEASE DEBUG_FLAGS=""
+
     steps:
       - uses: actions/checkout@v4
 
       - name: Install dependencies (Linux)
-        if: matrix.os == 'ubuntu-latest'
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y pkg-config libfreetype6-dev libcairo2-dev
 
       - name: Install dependencies (macOS)
-        if: matrix.os == 'macos-13'
+        if: runner.os == 'macOS'
         run: |
           brew install pkg-config freetype cairo
 
       - name: Build the tools
-        run: make all
+        run: make all ${{ matrix.extra_make_args }}
 
       - name: Publish build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
             extra_make_args: DEBUG=RELEASE DEBUG_FLAGS=""
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
@@ -42,7 +42,7 @@ jobs:
         run: make all ${{ matrix.extra_make_args }}
 
       - name: Publish build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Blackbox tools artifacts ${{matrix.name}}
           path: obj/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
             os: ubuntu-24.04-arm
             extra_make_args: DEBUG=RELEASE DEBUG_FLAGS=""
 
+          - name: Windows (x86_64)
+            os: windows-latest
+
     steps:
       - uses: actions/checkout@v6
         with:
@@ -43,8 +46,27 @@ jobs:
         run: |
           brew install pkg-config freetype cairo
 
+      - name: Install dependencies (Windows)
+        if: runner.os == 'Windows'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: false
+          install: >-
+            make
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-pkg-config
+            mingw-w64-x86_64-cairo
+            mingw-w64-x86_64-freetype
+
       - name: Build the tools
+        if: runner.os != 'Windows'
         run: make all ${{ matrix.extra_make_args }}
+
+      - name: Build the tools (Windows)
+        if: runner.os == 'Windows'
+        shell: msys2 {0}
+        run: make all
 
       - name: Publish build artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build (${{ matrix.name }})
@@ -26,6 +29,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
             make_args: DEBUG=RELEASE DEBUG_FLAGS="" ARCH_FLAGS="-mcpu=apple-m1"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 
@@ -65,7 +65,7 @@ jobs:
           cp obj/encoder_testbed  dist/encoder_testbed-${{ matrix.name }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: blackbox-tools-${{ matrix.name }}
           path: dist/
@@ -79,7 +79,7 @@ jobs:
       contents: write
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: release-artifacts
           merge-multiple: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,10 @@ jobs:
             os: macos-15
             make_args: DEBUG=RELEASE DEBUG_FLAGS="" ARCH_FLAGS="-mcpu=apple-m1"
 
+          - name: windows-x86_64
+            os: windows-latest
+            make_args: DEBUG=RELEASE DEBUG_FLAGS=""
+
     steps:
       - uses: actions/checkout@v6
         with:
@@ -59,16 +63,46 @@ jobs:
         run: |
           brew install pkg-config freetype cairo
 
+      - name: Install dependencies (Windows)
+        if: runner.os == 'Windows'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: false
+          install: >-
+            make
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-pkg-config
+            mingw-w64-x86_64-cairo
+            mingw-w64-x86_64-freetype
+
       - name: Build
+        if: runner.os != 'Windows'
+        run: make all ${{ matrix.make_args }}
+
+      - name: Build (Windows)
+        if: runner.os == 'Windows'
+        shell: msys2 {0}
         run: make all ${{ matrix.make_args }}
 
       - name: Strip and package binaries
+        if: runner.os != 'Windows'
         run: |
           strip obj/blackbox_decode obj/blackbox_render obj/encoder_testbed
           mkdir -p dist
           cp obj/blackbox_decode  dist/blackbox_decode-${{ matrix.name }}
           cp obj/blackbox_render  dist/blackbox_render-${{ matrix.name }}
           cp obj/encoder_testbed  dist/encoder_testbed-${{ matrix.name }}
+
+      - name: Strip and package binaries (Windows)
+        if: runner.os == 'Windows'
+        shell: msys2 {0}
+        run: |
+          strip obj/blackbox_decode.exe obj/blackbox_render.exe obj/encoder_testbed.exe
+          mkdir -p dist
+          cp obj/blackbox_decode.exe  dist/blackbox_decode-${{ matrix.name }}.exe
+          cp obj/blackbox_render.exe  dist/blackbox_render-${{ matrix.name }}.exe
+          cp obj/encoder_testbed.exe  dist/encoder_testbed-${{ matrix.name }}.exe
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,15 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         include:
@@ -41,6 +46,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+          persist-credentials: false
 
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,97 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g. v0.4.4)'
+        required: true
+      prerelease:
+        description: 'Mark as pre-release'
+        type: boolean
+        default: false
+
+jobs:
+  build:
+    name: Build (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - name: linux-x86_64
+            os: ubuntu-latest
+            make_args: DEBUG=RELEASE DEBUG_FLAGS=""
+
+          - name: linux-aarch64
+            os: ubuntu-24.04-arm
+            make_args: DEBUG=RELEASE DEBUG_FLAGS=""
+
+          - name: macos-x86_64
+            os: macos-13
+            make_args: DEBUG=RELEASE DEBUG_FLAGS=""
+
+          - name: macos-arm64
+            os: macos-15
+            make_args: DEBUG=RELEASE DEBUG_FLAGS="" ARCH_FLAGS="-mcpu=apple-m1"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libfreetype6-dev libcairo2-dev
+
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install pkg-config freetype cairo
+
+      - name: Build
+        run: make all ${{ matrix.make_args }}
+
+      - name: Strip and package binaries
+        run: |
+          strip obj/blackbox_decode obj/blackbox_render obj/encoder_testbed
+          mkdir -p dist
+          cp obj/blackbox_decode  dist/blackbox_decode-${{ matrix.name }}
+          cp obj/blackbox_render  dist/blackbox_render-${{ matrix.name }}
+          cp obj/encoder_testbed  dist/encoder_testbed-${{ matrix.name }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: blackbox-tools-${{ matrix.name }}
+          path: dist/
+          retention-days: 7
+
+  release:
+    name: Publish Release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-artifacts
+          merge-multiple: true
+
+      - name: List artifacts
+        run: ls -lh release-artifacts/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+          name: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+          prerelease: ${{ github.event_name == 'workflow_dispatch' && inputs.prerelease || false }}
+          generate_release_notes: true
+          files: release-artifacts/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
             make_args: DEBUG=RELEASE DEBUG_FLAGS=""
 
           - name: macos-x86_64
-            os: macos-13
+            os: macos-15-intel
             make_args: DEBUG=RELEASE DEBUG_FLAGS=""
 
           - name: macos-arm64

--- a/Makefile
+++ b/Makefile
@@ -73,14 +73,15 @@ CFLAGS		= $(ARCH_FLAGS) \
 		-pthread \
 		-Wall -pedantic -Wextra -Wshadow
 
-CFLAGS += `pkg-config --cflags cairo` `pkg-config --cflags freetype2`
+# cairo and freetype are only needed by blackbox_render
+RENDERER_CFLAGS = `pkg-config --cflags cairo` `pkg-config --cflags freetype2`
 
 ifeq ($(BUILD_STATIC), MACOSX)
 	# For cairo built with ./configure --enable-quartz=no  --without-x --enable-pdf=no --enable-ps=no --enable-script=no --enable-xcb=no --enable-ft=yes --enable-fc=no --enable-xlib=no
-	LDFLAGS += -Llib/macosx -lcairo -lpixman-1 -lpng16 -lz -lfreetype -lbz2
+	RENDERER_LDFLAGS += -Llib/macosx -lcairo -lpixman-1 -lpng16 -lz -lfreetype -lbz2
 else
 	# Dynamic linking
-	LDFLAGS += `pkg-config --libs cairo` `pkg-config --libs freetype2`
+	RENDERER_LDFLAGS += `pkg-config --libs cairo` `pkg-config --libs freetype2`
 endif
 
 LDFLAGS += -lm
@@ -113,12 +114,17 @@ $(DECODER_ELF):  $(DECODER_OBJS)
 	@$(CC) -o $@ $^ $(LDFLAGS)
 
 $(RENDERER_ELF):  $(RENDERER_OBJS)
-	@$(CC) -o $@ $^ $(LDFLAGS)
+	@$(CC) -o $@ $^ $(LDFLAGS) $(RENDERER_LDFLAGS)
 
 $(ENCODER_TESTBED_ELF): $(ENCODER_TESTBED_OBJS)
 	@$(CC) -o $@ $^ $(LDFLAGS)
 
 # Compile
+$(OBJECT_DIR)/blackbox_render.o: blackbox_render.c
+	@mkdir -p $(dir $@)
+	@echo %% $(notdir $<)
+	@$(CC) -c -o $@ $(CFLAGS) $(RENDERER_CFLAGS) $<
+
 $(OBJECT_DIR)/%.o: %.c
 	@mkdir -p $(dir $@)
 	@echo %% $(notdir $<)


### PR DESCRIPTION
## Changes

- **Fix:** scope cairo/freetype CFLAGS/LDFLAGS to `blackbox_render` only — `blackbox_decode` and `encoder_testbed` don't use either library; global linkage produced binaries with unnecessary dylib dependencies breaking distribution on machines without Homebrew
- Replace deprecated `macos-13` with `macos-15-intel`; fix dep install steps to use `runner.os` so all runners get packages
- Add Linux arm64 (`ubuntu-24.04-arm`) and macOS arm64 (`macos-15`) to CI matrix
- Bump actions to Node 24-compatible versions (`checkout@v6`, `upload-artifact@v7`, `download-artifact@v8`)
- Add `release.yml`: builds all 4 targets on `v*.*.*` tag push or manual dispatch, publishes a GitHub Release with per-platform named binaries

## Tested

| | Result |
|---|---|
| `blackbox_decode` macOS arm64 (native) — 12 BFL logs, 0 frame failures | ✓ |
| `blackbox_decode` macOS x86_64 via Rosetta 2 — 12 BFL logs, 0 frame failures | ✓ |

Linux and Windows builds not manually validated. `blackbox_render` not tested (requires display output). Release workflow validated on fork (`SuperSecureHuman/blackbox-tools`).

---
*Generated with Claude (Anthropic) and manually validated on macOS.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI expanded to run builds across multiple OS/architectures (including macOS Intel/Apple Silicon, Linux and Windows) with per-target build jobs.
  * New release workflow produces per-platform artifacts, consolidates them, and creates GitHub Releases (supports tag pushes and manual dispatch).
  * Build configuration refined to scope renderer build flags for more reliable cross-platform packaging and reproducible artifacts.
  * Updated CI actions, permissions and packaging steps for steadier releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/blackbox-tools/pull/66?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->