### PR TITLE
ci: bump macOS runner from macos-13 to macos-15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
             os: ubuntu-latest
 
           - name: macOS
-            os: macos-13
+            os: macos-15
 
     steps:
       - uses: actions/checkout@v4
@@ -26,7 +26,7 @@ jobs:
           sudo apt-get install -y pkg-config libfreetype6-dev libcairo2-dev
 
       - name: Install dependencies (macOS)
-        if: matrix.os == 'macos-13'
+        if: matrix.os == 'macos-15'
         run: |
           brew install pkg-config freetype cairo
 


### PR DESCRIPTION
AI Generated pull-request

## Summary
- `macos-13` is no longer among GitHub's currently offered hosted runner images, and `macos-14` began its deprecation cycle on 2026-07-06 (full removal by 2026-11-02) — both were at risk of failing to schedule.
- Bumps the macOS CI job to `macos-15`, which is current, GA, and matches what `macos-latest` resolves to as of this writing.
- Updates the matching `if: matrix.os == 'macos-15'` condition on the dependency-install step to keep it in sync with the matrix value.

## Test plan
- [ ] CI passes on both `Linux` and `macOS` matrix legs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the macOS build job to use a newer runner version, helping keep automated checks current.
  * Adjusted the macOS-specific setup step to match the updated build environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->