### PR TITLE
Add explicit permissions blocks for read-default GITHUB_TOKEN

### DIFF
--- a/.github/workflows/artifact-links.yml
+++ b/.github/workflows/artifact-links.yml
@@ -4,6 +4,9 @@ on:
     workflows: ["PR"]
     types: [completed]
 
+permissions:
+  pull-requests: write
+
 jobs:
   artifacts-url-comments:
     name: Add artifact links to PR and issues

--- a/.github/workflows/hide-artifact-links.yml
+++ b/.github/workflows/hide-artifact-links.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     types: [synchronize, reopened]
 
+permissions:
+  pull-requests: write
+
 jobs:
   hide-artifacts-link-comments:
     name: Hide artifact links

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -6,6 +6,10 @@ on:
   schedule:
     - cron: 0 4 * * *
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   no-response:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -4,6 +4,10 @@ on:
   schedule:
   - cron: "30 4 * * *"
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     name: 'Check and close stale issues'


### PR DESCRIPTION
The org default GITHUB_TOKEN permission is now read. These workflows write with GITHUB_TOKEN (stale labelling/closing, PR comment actions) and need explicit permissions to keep working.